### PR TITLE
Adding make_hpge.py and handling some exceptions

### DIFF
--- a/src/legendhpges/__init__.py
+++ b/src/legendhpges/__init__.py
@@ -1,7 +1,8 @@
 from ._version import version as __version__
 from .bege import BEGe
 from .invcoax import InvertedCoax
+from .make_hpge import make_hpge
 from .ppc import PPC
 from .semicoax import SemiCoax
 
-__all__ = ["__version__", "InvertedCoax", "BEGe", "PPC", "SemiCoax"]
+__all__ = ["__version__", "InvertedCoax", "BEGe", "PPC", "SemiCoax", "make_hpge"]

--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -52,6 +52,8 @@ class HPGe(ABC, geant4.LogicalVolume):
 
         if name is None:
             self.name = self.metadata.name
+        else:
+            self.name = name
 
         # return ordered r,z lists, default unit [mm]
         r, z = self._decode_polycone_coord()

--- a/src/legendhpges/make_hpge.py
+++ b/src/legendhpges/make_hpge.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+from legendmeta.jsondb import AttrsDict
+from pyg4ometry import geant4
+
+from .bege import BEGe
+from .invcoax import InvertedCoax
+from .materials import _enriched_germanium
+from .ppc import PPC
+from .registry import default_g4_registry
+from .semicoax import SemiCoax
+
+
+def make_hpge(
+    metadata: str | dict | AttrsDict,
+    registry: geant4.Registry = default_g4_registry,
+    **kwargs,
+) -> geant4.LogicalVolume:
+    """Costructing an HPGe detector logical volume based on the detector metadata.
+
+    Parameters
+    ----------
+    metadata
+        LEGEND HPGe configuration metadata file containing
+        detector static properties.
+    registry
+        pyg4ometry Geant4 registry instance.
+
+    Other Parameters
+    ----------------
+    **kwargs
+        Additionally, the following arguments are allowed for
+        overriding the name and the material from the metadata:
+
+        name
+            name to attach to the detector. Used to name
+            solid and logical volume.
+        material
+            pyg4ometry Geant4 material for the detector.
+
+    Examples
+    --------
+        >>> gedet = make_hpge(metadata, registry)
+
+        >>> make_hpge(metadata, registry, name = "my_det", material = my_material)
+
+    """
+    if not isinstance(metadata, (dict, AttrsDict)):
+        with open(metadata) as jfile:
+            gedet_meta = AttrsDict(json.load(jfile))
+    else:
+        gedet_meta = AttrsDict(metadata)
+
+    kwargs.setdefault("material", _enriched_germanium(gedet_meta.production.enrichment))
+    kwargs.setdefault("name", gedet_meta.name)
+
+    if gedet_meta.type == "ppc":
+        gedet = PPC(metadata, registry=registry, **kwargs)
+
+    elif gedet_meta.type == "bege":
+        gedet = BEGe(metadata, registry=registry, **kwargs)
+
+    elif gedet_meta.type == "icpc":
+        gedet = InvertedCoax(metadata, registry=registry, **kwargs)
+
+    elif gedet_meta.type == "coax":
+        gedet = SemiCoax(metadata, registry=registry, **kwargs)
+
+    return gedet

--- a/src/legendhpges/materials.py
+++ b/src/legendhpges/materials.py
@@ -18,14 +18,19 @@ ge76 = geant4.Isotope("Ge76", 32, 76, 75.9214)
 
 def _enriched_germanium(ge76_fraction: float = 0.92) -> geant4.MaterialCompound:
     """Enriched Germanium builder."""
-    enrge = geant4.ElementIsotopeMixture(f"Germanium{ge76_fraction:.3f}", "EnrGe", 2)
-    # approximation
-    enrge.add_isotope(ge74, 1 - ge76_fraction)
-    enrge.add_isotope(ge76, ge76_fraction)
-    matenrge = geant4.MaterialCompound(
-        f"EnrichedGermanium{ge76_fraction:.3f}", 5.56, 1, default_g4_registry
-    )
-    matenrge.add_element_massfraction(enrge, 1)
+    enrge_name = f"EnrichedGermanium{ge76_fraction:.3f}"
+
+    if enrge_name not in default_g4_registry.materialDict:
+        enrge = geant4.ElementIsotopeMixture(
+            f"Germanium{ge76_fraction:.3f}", "EnrGe", 2
+        )
+        # approximation
+        enrge.add_isotope(ge74, 1 - ge76_fraction)
+        enrge.add_isotope(ge76, ge76_fraction)
+        matenrge = geant4.MaterialCompound(enrge_name, 5.56, 1, default_g4_registry)
+        matenrge.add_element_massfraction(enrge, 1)
+    else:
+        matenrge = default_g4_registry.materialDict[enrge_name]
     return matenrge
 
 

--- a/tests/test_det_profile.py
+++ b/tests/test_det_profile.py
@@ -2,7 +2,7 @@ import pytest
 from legendtestdata import LegendTestData
 from pyg4ometry import geant4
 
-from legendhpges import PPC, BEGe, InvertedCoax, SemiCoax
+from legendhpges import PPC, BEGe, InvertedCoax, SemiCoax, make_hpge
 from legendhpges.materials import enriched_germanium
 
 reg = geant4.Registry()
@@ -34,3 +34,23 @@ def test_semicoax(test_data_configs):
     SemiCoax(
         test_data_configs + "/C99000A.json", material=enriched_germanium, registry=reg
     )
+
+
+def test_make_icpc(test_data_configs):
+    gedet = make_hpge(test_data_configs + "/V99000A.json")
+    assert isinstance(gedet, InvertedCoax)
+
+
+def test_make_bege(test_data_configs):
+    gedet = make_hpge(test_data_configs + "/B99000A.json")
+    assert isinstance(gedet, BEGe)
+
+
+def test_make_ppc(test_data_configs):
+    gedet = make_hpge(test_data_configs + "/P99000A.json")
+    assert isinstance(gedet, PPC)
+
+
+def test_make_semicoax(test_data_configs):
+    gedet = make_hpge(test_data_configs + "/C99000A.json")
+    assert isinstance(gedet, SemiCoax)


### PR DESCRIPTION
Adding functionality for HPGe detector construction directly from the metadata. Exeptions handled:

- IdenticalNameError exception from pyg4ometry.geant4.Registry.addMaterial when defining material with the same enrichment argument.
- AttributeError in `HPGe` class when supplying `name` argument for detector construction.