### PR TITLE
also implement reading enrichment from future metadata scheme

### DIFF
--- a/src/legendhpges/make_hpge.py
+++ b/src/legendhpges/make_hpge.py
@@ -65,7 +65,13 @@ def make_hpge(
         if gedet_meta.production.enrichment is None:
             msg = "The enrichment argument in the metadata is None."
             raise ValueError(msg)
-        kwargs["material"] = make_enriched_germanium(gedet_meta.production.enrichment)
+        # representation of enrichment data changed in legend-exp/legend-detectors PR #43 to
+        # value and uncertainty.
+        if isinstance(gedet_meta.production.enrichment, float):
+            enrichment = gedet_meta.production.enrichment
+        else:
+            enrichment = gedet_meta.production.enrichment.val
+        kwargs["material"] = make_enriched_germanium(enrichment)
 
     if name is None:
         if gedet_meta.name is None:

--- a/src/legendhpges/materials.py
+++ b/src/legendhpges/materials.py
@@ -75,7 +75,7 @@ def _make_natural_germanium() -> g4.MaterialCompound:
     return matenrge
 
 
-def enriched_germanium_density(ge76_fraction: float = 0.92) -> float:
+def enriched_germanium_density(ge76_fraction: float = 0.92) -> Quantity:
     """Calculate the density of enriched germanium.
 
     Parameters
@@ -90,7 +90,7 @@ def enriched_germanium_density(ge76_fraction: float = 0.92) -> float:
     return (_number_density_meas() * m_eff / n_avogadro).to("g/cm^3")
 
 
-def make_enriched_germanium(ge76_fraction: float = 0.92) -> g4.MaterialCompound:
+def make_enriched_germanium(ge76_fraction: float = 0.92) -> g4.Material:
     """Enriched germanium material builder.
 
     Note


### PR DESCRIPTION
after https://github.com/legend-exp/legend-detectors/pull/43, the enrichment is not stored as float, but as an object `{ "val": X, "unc": Y }`

That change is not part of a tagged legend-metadata release yet, so this PR is not urgent.

Also change two return types to the correct values.