### PR TITLE
Fix deprecation warning with pint 0.24

### DIFF
--- a/src/legendhpges/registry.py
+++ b/src/legendhpges/registry.py
@@ -9,4 +9,7 @@ default_g4_registry = geant4.Registry()
 default_units_registry = pint.get_application_registry()
 """Default Pint physical units registry."""
 
-default_units_registry.default_format = "~P"
+if hasattr(default_units_registry, "formatter"):  # pint >= 0.24
+    default_units_registry.formatter.default_format = "~P"
+else:  # pint <= 0.23
+    default_units_registry.default_format = "~P"


### PR DESCRIPTION
The 0.24 release of pint (some days ago) deprecates the `default_format` attribute of the registry

* The replacement  `UnitRegistry.formatter`  also has been added only to 0.24: https://github.com/hgrecco/pint/commit/6c3716f3911015ddf7e3880ac688b1ed76d438e3
* The deprecation warning is from https://github.com/hgrecco/pint/commit/17c2143386349fc503d6b01b4b84d8db85ed06df

So add a conditional check to set the correct (non-deprecated) attribute depending on pint version