### PR TITLE
propagate registry object to material creation

### DIFF
--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -9,7 +9,7 @@ from legendmeta import AttrsDict
 from pint import Quantity
 from pyg4ometry import geant4
 
-from .materials import natural_germanium
+from .materials import make_natural_germanium
 from .registry import default_g4_registry
 from .registry import default_units_registry as u
 
@@ -36,7 +36,7 @@ class HPGe(ABC, geant4.LogicalVolume):
         metadata: str | dict | AttrsDict,
         name: str | None = None,
         registry: geant4.Registry = default_g4_registry,
-        material: geant4.MaterialCompound = natural_germanium,
+        material: geant4.MaterialCompound = None,
     ) -> None:
         if registry is None:
             msg = "registry cannot be None"
@@ -45,6 +45,9 @@ class HPGe(ABC, geant4.LogicalVolume):
         if metadata is None:
             msg = "metadata cannot be None"
             raise ValueError(msg)
+
+        if material is None:
+            material = make_natural_germanium(registry)
 
         # build crystal, declare as detector
         if not isinstance(metadata, (dict, AttrsDict)):

--- a/src/legendhpges/make_hpge.py
+++ b/src/legendhpges/make_hpge.py
@@ -71,7 +71,7 @@ def make_hpge(
             enrichment = gedet_meta.production.enrichment
         else:
             enrichment = gedet_meta.production.enrichment.val
-        kwargs["material"] = make_enriched_germanium(enrichment)
+        kwargs["material"] = make_enriched_germanium(enrichment, registry)
 
     if name is None:
         if gedet_meta.name is None:

--- a/src/legendhpges/materials.py
+++ b/src/legendhpges/materials.py
@@ -56,23 +56,22 @@ def _number_density_meas() -> Quantity:
     return n_avogadro * natge_density_meas / a_eff
 
 
-def _make_natural_germanium() -> g4.MaterialCompound:
+def make_natural_germanium(
+    registry: g4.Registry = default_g4_registry,
+) -> g4.MaterialCompound:
     """Natural germanium material builder."""
     enrge_name = "NaturalGermanium"
 
-    if enrge_name not in default_g4_registry.materialDict:
+    if enrge_name not in registry.materialDict:
         enrge = g4.ElementIsotopeMixture(enrge_name, "NatGe", len(natge_isotopes))
 
         for iso, frac in natge_isotopes.items():
             enrge.add_isotope(iso, frac)
 
-        matenrge = g4.MaterialCompound(
-            enrge_name, natge_density_meas.m, 1, default_g4_registry
-        )
+        matenrge = g4.MaterialCompound(enrge_name, natge_density_meas.m, 1, registry)
         matenrge.add_element_massfraction(enrge, 1)
-    else:
-        matenrge = default_g4_registry.materialDict[enrge_name]
-    return matenrge
+
+    return registry.materialDict[enrge_name]
 
 
 def enriched_germanium_density(ge76_fraction: float = 0.92) -> Quantity:
@@ -90,7 +89,10 @@ def enriched_germanium_density(ge76_fraction: float = 0.92) -> Quantity:
     return (_number_density_meas() * m_eff / n_avogadro).to("g/cm^3")
 
 
-def make_enriched_germanium(ge76_fraction: float = 0.92) -> g4.Material:
+def make_enriched_germanium(
+    ge76_fraction: float = 0.92,
+    registry: g4.Registry = default_g4_registry,
+) -> g4.Material:
     """Enriched germanium material builder.
 
     Note
@@ -104,8 +106,8 @@ def make_enriched_germanium(ge76_fraction: float = 0.92) -> g4.Material:
     """
     enrge_name = f"EnrichedGermanium{ge76_fraction:.3f}"
 
-    if enrge_name not in default_g4_registry.materialDict:
-        enrge = g4.ElementIsotopeMixture(enrge_name, "EnrGe", 2)
+    if enrge_name not in registry.materialDict:
+        enrge = g4.ElementIsotopeMixture(f"Element{enrge_name}", "EnrGe", 2, registry)
         enrge.add_isotope(ge74, 1 - ge76_fraction)
         enrge.add_isotope(ge76, ge76_fraction)
 
@@ -113,13 +115,8 @@ def make_enriched_germanium(ge76_fraction: float = 0.92) -> g4.Material:
             enrge_name,
             enriched_germanium_density(ge76_fraction).to("g/cm^3").m,
             1,
-            default_g4_registry,
+            registry,
         )
         matenrge.add_element_massfraction(enrge, 1)
-    else:
-        matenrge = default_g4_registry.materialDict[enrge_name]
-    return matenrge
 
-
-natural_germanium: g4.MaterialCompound = _make_natural_germanium()
-enriched_germanium: g4.MaterialCompound = make_enriched_germanium()
+    return registry.materialDict[enrge_name]

--- a/tests/test_det_profile.py
+++ b/tests/test_det_profile.py
@@ -18,9 +18,10 @@ from legendhpges import (
     SemiCoax,
     make_hpge,
 )
-from legendhpges.materials import natural_germanium
+from legendhpges.materials import make_natural_germanium
 
 reg = geant4.Registry()
+natural_germanium = make_natural_germanium(reg)
 configs = TextDB(pathlib.Path(__file__).parent.resolve() / "configs")
 
 

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -26,6 +26,6 @@ def test_g4_materials():
         == materials.enriched_germanium_density(0.92).to("g/cm^3").m
     )
     assert (
-        materials.natural_germanium.density
+        materials.make_natural_germanium().density
         == materials.natge_density_meas.to("g/cm^3").m
     )


### PR DESCRIPTION
This prevented pyg4ometry from (in-)correctly validating material name duplicates. Also fix the duplicates, so that pyg4ometry can read back generated GDML files.

also see https://github.com/g4edge/pyg4ometry/issues/195 for background

**important note**: while pyg4ometry could not read the generated files, Geant4 alsways could without problems. So this bug did never impact actual simulation runs, only people trying to read data from the GDML file.