### PR TITLE
fix setting registry=None

### DIFF
--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -45,6 +45,12 @@ class HPGe(ABC, geant4.LogicalVolume):
         if metadata is None:
             msg = "metadata cannot be None"
             raise ValueError(msg)
+        if registry is None:
+            msg = "registry cannot be None"
+            raise ValueError(msg)
+
+        if material is not None and material.registry != registry:
+            raise ValueError()
 
         if material is None:
             material = make_natural_germanium(registry)

--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -50,7 +50,8 @@ class HPGe(ABC, geant4.LogicalVolume):
             raise ValueError(msg)
 
         if material is not None and material.registry != registry:
-            raise ValueError()
+            msg = "material has different registry than HPGe det"
+            raise ValueError(msg)
 
         if material is None:
             material = make_natural_germanium(registry)

--- a/src/legendhpges/make_hpge.py
+++ b/src/legendhpges/make_hpge.py
@@ -65,6 +65,9 @@ def make_hpge(
     material = kwargs.get("material")
     name = kwargs.get("name")
 
+    if registry is None:
+        registry = geant4.Registry()
+
     if material is None:
         if gedet_meta.production.enrichment is None:
             msg = "The enrichment argument in the metadata is None."

--- a/tests/test_det_profile.py
+++ b/tests/test_det_profile.py
@@ -30,9 +30,9 @@ def test_data_configs():
     return ldata.get_path("legend/metadata/hardware/detectors/germanium/diodes")
 
 
-@pytest.fixture
-def reg():
-    return geant4.Registry()
+@pytest.fixture(params=["r", "n"])
+def reg(request):
+    return geant4.Registry() if request.param == "r" else None
 
 
 @pytest.fixture

--- a/tests/test_det_profile.py
+++ b/tests/test_det_profile.py
@@ -30,8 +30,13 @@ def test_data_configs():
     return ldata.get_path("legend/metadata/hardware/detectors/germanium/diodes")
 
 
+@pytest.fixture()
+def reg():
+    return geant4.Registry()
+
+
 @pytest.fixture(params=["r", "n"])
-def reg(request):
+def reg_or_none(request):
     return geant4.Registry() if request.param == "r" else None
 
 
@@ -76,43 +81,43 @@ def test_v02160a(reg, natural_germanium):
     V02160A(configs.V02160A, material=natural_germanium, registry=reg)
 
 
-def test_make_icpc(test_data_configs, reg):
-    gedet = make_hpge(test_data_configs + "/V99000A.json", registry=reg)
+def test_make_icpc(test_data_configs, reg_or_none):
+    gedet = make_hpge(test_data_configs + "/V99000A.json", registry=reg_or_none)
     assert isinstance(gedet, InvertedCoax)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_make_bege(test_data_configs, reg):
-    gedet = make_hpge(test_data_configs + "/B99000A.json", registry=reg)
+def test_make_bege(test_data_configs, reg_or_none):
+    gedet = make_hpge(test_data_configs + "/B99000A.json", registry=reg_or_none)
     assert isinstance(gedet, BEGe)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_make_ppc(test_data_configs, reg):
-    gedet = make_hpge(test_data_configs + "/P99000A.json", registry=reg)
+def test_make_ppc(test_data_configs, reg_or_none):
+    gedet = make_hpge(test_data_configs + "/P99000A.json", registry=reg_or_none)
     assert isinstance(gedet, PPC)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_make_semicoax(test_data_configs, reg):
-    gedet = make_hpge(test_data_configs + "/C99000A.json", registry=reg)
+def test_make_semicoax(test_data_configs, reg_or_none):
+    gedet = make_hpge(test_data_configs + "/C99000A.json", registry=reg_or_none)
     assert isinstance(gedet, SemiCoax)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def make_v07646a(reg):
-    gedet = make_hpge(configs.V07646A, registry=reg)
+def make_v07646a(reg_or_none):
+    gedet = make_hpge(configs.V07646A, registry=reg_or_none)
     assert isinstance(gedet, V07646A)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_make_p00664b(reg):
-    gedet = make_hpge(configs.P00664B, registry=reg)
+def test_make_p00664b(reg_or_none):
+    gedet = make_hpge(configs.P00664B, registry=reg_or_none)
     assert gedet.mass
     assert isinstance(gedet, P00664B)
 
@@ -122,30 +127,31 @@ def test_make_p00664b(reg):
         configs.P00664B,
         name="P00664B_bis",
         allow_cylindrical_asymmetry=False,
-        registry=reg,
+        registry=reg_or_none,
     )
     assert isinstance(gedet, PPC)
     assert not isinstance(gedet, P00664B)
     assert isinstance(gedet.solid, geant4.solid.GenericPolycone)
 
 
-def test_make_v02162b(reg):
-    gedet = make_hpge(configs.V02162B, registry=reg)
+def test_make_v02162b(reg_or_none):
+    gedet = make_hpge(configs.V02162B, registry=reg_or_none)
     assert gedet.mass
     assert isinstance(gedet, V02162B)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_make_v02160a(reg):
-    gedet = make_hpge(configs.V02160A, registry=reg)
+def test_make_v02160a(reg_or_none):
+    gedet = make_hpge(configs.V02160A, registry=reg_or_none)
     assert gedet.mass
     assert isinstance(gedet, V02160A)
 
     assert len(gedet._decode_polycone_coord()[0]) == len(gedet.surfaces) + 1
 
 
-def test_null_enrichment(reg, natural_germanium):
+def test_null_enrichment(reg_or_none):
     metadata = configs.V07646A
     metadata.production.enrichment = None
-    make_hpge(metadata, registry=reg, material=natural_germanium, name="my_gedet")
+    with pytest.raises(ValueError):
+        make_hpge(metadata, registry=reg_or_none, name="my_gedet")

--- a/tests/test_det_profile.py
+++ b/tests/test_det_profile.py
@@ -30,7 +30,7 @@ def test_data_configs():
     return ldata.get_path("legend/metadata/hardware/detectors/germanium/diodes")
 
 
-@pytest.fixture()
+@pytest.fixture
 def reg():
     return geant4.Registry()
 

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -8,13 +8,8 @@ from legendmeta import TextDB
 from legendtestdata import LegendTestData
 from pyg4ometry import geant4
 
-from legendhpges import (
-    make_hpge,
-)
-from legendhpges.materials import make_natural_germanium
+from legendhpges import make_hpge
 
-reg = geant4.Registry()
-natural_germanium = make_natural_germanium(reg)
 configs = TextDB(pathlib.Path(__file__).parent.resolve() / "configs")
 
 
@@ -25,24 +20,26 @@ def test_data_configs():
     return ldata.get_path("legend/metadata/hardware/detectors/germanium/diodes")
 
 
-def test_not_implemented():
-    reg = geant4.Registry()
+@pytest.fixture(params=["r", "n"])
+def reg(request):
+    return geant4.Registry() if request.param == "r" else None
+
+
+def test_not_implemented(reg):
     ppc = make_hpge(configs.P00664B, registry=reg)
 
     with pytest.raises(NotImplementedError):
         ppc.distance_to_surface([[1, 0, 0]])
 
 
-def test_bad_dimensions(test_data_configs):
-    reg = geant4.Registry()
+def test_bad_dimensions(test_data_configs, reg):
     gedet = make_hpge(test_data_configs + "/C99000A.json", registry=reg)
 
     with pytest.raises(ValueError):
         gedet.distance_to_surface([[1, 0, 0, 0]])
 
 
-def test_output(test_data_configs):
-    reg = geant4.Registry()
+def test_output(test_data_configs, reg):
     gedet = make_hpge(test_data_configs + "/C99000A.json", registry=reg)
     dist = gedet.distance_to_surface([[0, 0, 0], [1, 3, 3], [0, 0, 0]])
 
@@ -55,25 +52,21 @@ def test_output(test_data_configs):
     assert np.all(dist_indices >= dist)
 
 
-def test_inside_not_implemented():
-    reg = geant4.Registry()
+def test_inside_not_implemented(reg):
     ppc = make_hpge(configs.P00664B, registry=reg)
 
     with pytest.raises(NotImplementedError):
         ppc.is_inside([[1, 0, 0]])
 
 
-def test_inside_bad_dimensions(test_data_configs):
-    reg = geant4.Registry()
+def test_inside_bad_dimensions(test_data_configs, reg):
     gedet = make_hpge(test_data_configs + "/C99000A.json", registry=reg)
 
     with pytest.raises(ValueError):
         gedet.is_inside([[1, 0, 0, 0]])
 
 
-def test_inside_output(test_data_configs):
-    reg = geant4.Registry()
-
+def test_inside_output(test_data_configs, reg):
     gedet = make_hpge(test_data_configs + "/B99000A.json", registry=reg)
     r, z = gedet._decode_polycone_coord()
 


### PR DESCRIPTION
the original approach did not work with all things in pyg4ometry, so we need to construct a temporary registry if we pass `None`.