### PR TITLE
alternative method for horizontal/vertical segements in distance to surface

### DIFF
--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -177,6 +177,9 @@ class HPGe(ABC, geant4.LogicalVolume):
         tol
             distance outside the surface which is considered inside. Should be
             on the order of numerical precision of the floating point representation.
+        signed
+            whether to return signed distanced (inside the HPGe is positive,
+            outside is negative).
 
         Note
         ----

--- a/src/legendhpges/base.py
+++ b/src/legendhpges/base.py
@@ -202,7 +202,7 @@ class HPGe(ABC, geant4.LogicalVolume):
         # convert coords
         coords_rz = utils.convert_coords(coords)
 
-        return utils.iterate_segements(s1, s2, coords_rz, tol, signed)
+        return utils.iterate_segments(s1, s2, coords_rz, tol, signed)
 
     @property
     def volume(self) -> Quantity:

--- a/src/legendhpges/utils.py
+++ b/src/legendhpges/utils.py
@@ -122,7 +122,7 @@ def get_line_segments(
     return s1, s2
 
 
-@numba.njit(cache=True)
+# @numba.njit(cache=True)
 def shortest_distance(
     s1_list: NDArray,
     s2_list: NDArray,
@@ -186,36 +186,129 @@ def shortest_distance(
     for segment in range(n_segments):
         s1 = s1_list[segment]
         s2 = s2_list[segment]
+        # check if vertical or horizontal
+        # Ensure s2's coordinate is always >= s1's coordinate for simpler logic
+        if (s1[0] > s2[0]) or (s1[1] > s2[1]):
+            s1, s2 = s2, s1
+            sign_factor = -1
+        else:
+            sign_factor = 1
 
-        n = (s2 - s1) / _norm(s2 - s1)
+        if abs(s1[0] - s2[0]) < tol:
+            # Compute distances for a vertical segment
+            x_level = s1[0]  # x-coordinate of the vertical line
+            y_min, y_max = s1[1], s2[1]
 
-        proj_dist = -_dot(n, (n * _dot(s1 - points, n)[:, np.newaxis]))
+            # Points that project onto the segment (y between y_min and y_max)
+            mask_on_segment = (points[:, 1] >= y_min) & (points[:, 1] <= y_max)
 
-        dist_vec = np.empty_like(s1 - points)
+            # Initialize distance vector
+            dist_vec = np.zeros_like(points)
 
-        condition1 = proj_dist < 0
-        condition2 = proj_dist > _norm(s2 - s1)
-        condition3 = (~condition1) & (~condition2)
+            # For points that project onto the segment (y within bounds)
+            x_diff = points[:, 0] - x_level
+            dist_vec[mask_on_segment, 0] = x_diff[mask_on_segment]
+            dist_vec[mask_on_segment, 1] = 0
 
-        diff_s1 = s1 - points
-        dist_vec[condition1] = diff_s1[condition1]
-        dist_vec[condition2] = s2 - points[condition2]
-        dist_vec[condition3] = (
-            diff_s1[condition3] - n * _dot(diff_s1, n)[condition3, np.newaxis]
-        )
+            # For points below the segment
+            mask_below = points[:, 1] < y_min
+            dist_vec[mask_below] = points[mask_below] - s1
 
-        # make this signed so inside is positive and outside negative
-        if signed:
-            sign_vec = n[0] * dist_vec[:, 1] - n[1] * dist_vec[:, 0]
+            # For points above the segment
+            mask_above = points[:, 1] > y_max
+            dist_vec[mask_above] = points[mask_above] - s2
 
-            # push points on surface inside
-            sign_vec = np.where(np.abs(sign_vec) < tol, -tol, sign_vec)
-            sign_vec_norm = -sign_vec / np.abs(sign_vec)
+            # Compute sign for vertical segment (positive to the right if s2>s1)
+            if signed:
+                sign_vec_norm = np.ones(len(points))
+                # If points are to the left of the line, sign is negative
+                sign_vec_norm[x_diff > 0 if sign_factor == 1 else x_diff < 0] = -1
+            else:
+                sign_vec_norm = np.ones(len(points))
+
+            normed_dist = np.abs(
+                np.where(
+                    dist_vec[:, 1] == 0,
+                    dist_vec[:, 0],
+                    _norm(dist_vec),
+                )
+            )
+
+        # check if horizontal segment
+        elif abs(s1[1] - s2[1]) < tol:
+            # Compute distances for a horizontal segment
+            y_level = s1[1]  # y-coordinate of the horizontal line
+            x_min, x_max = s1[0], s2[0]
+
+            # Points that project onto the segment (x between x_min and x_max)
+            mask_on_segment = (points[:, 0] >= x_min) & (points[:, 0] <= x_max)
+
+            # Initialize distance vector
+            dist_vec = np.zeros_like(points)
+
+            # For points that project onto the segment (x within bounds)
+            y_diff = points[:, 1] - y_level
+            dist_vec[mask_on_segment, 0] = 0
+            dist_vec[mask_on_segment, 1] = y_diff[mask_on_segment]
+
+            # For points to the left of the segment
+            mask_left = points[:, 0] < x_min
+            dist_vec[mask_left] = points[mask_left] - s1
+
+            # For points to the right of the segment
+            mask_right = points[:, 0] > x_max
+            dist_vec[mask_right] = points[mask_right] - s2
+            # Compute sign for horizontal segment (positive above if s2>s1)
+            if signed:
+                sign_vec_norm = np.ones(len(points))
+                # If points are below the line, sign is negative
+                sign_vec_norm[y_diff < 0 if sign_factor == 1 else y_diff > 0] = -1
+            else:
+                sign_vec_norm = np.ones(len(points))
+
+            normed_dist = np.abs(
+                np.where(
+                    dist_vec[:, 0] == 0,
+                    dist_vec[:, 1],
+                    _norm(dist_vec),
+                )
+            )
 
         else:
-            sign_vec_norm = np.ones(len(dist_vec))
+            n = (s2 - s1) / _norm(s2 - s1)
+
+            proj_dist = -_dot(n, (n * _dot(s1 - points, n)[:, np.newaxis]))
+
+            dist_vec = np.empty_like(s1 - points)
+
+            condition1 = proj_dist < 0
+            condition2 = proj_dist > _norm(s2 - s1)
+            condition3 = (~condition1) & (~condition2)
+
+            diff_s1 = s1 - points
+            dist_vec[condition1] = diff_s1[condition1]
+            dist_vec[condition2] = s2 - points[condition2]
+            dist_vec[condition3] = (
+                diff_s1[condition3] - n * _dot(diff_s1, n)[condition3, np.newaxis]
+            )
+
+            # make this signed so inside is positive and outside negative
+            if signed:
+                sign_vec = n[0] * dist_vec[:, 1] - n[1] * dist_vec[:, 0]
+
+                # push points on surface inside
+                sign_vec = (
+                    np.where(np.abs(sign_vec) < tol, -tol, sign_vec) * sign_factor
+                )
+                sign_vec_norm = -sign_vec / np.abs(sign_vec)
+
+            else:
+                sign_vec_norm = np.ones(len(dist_vec))
+            normed_dist = np.abs(_norm(dist_vec))
 
         dists[:, segment] = np.where(
-            np.abs(_norm(dist_vec)) < tol, tol, np.abs(_norm(dist_vec)) * sign_vec_norm
+            normed_dist < tol,
+            tol,
+            normed_dist * sign_vec_norm,
         )
     return dists

--- a/src/legendhpges/utils.py
+++ b/src/legendhpges/utils.py
@@ -122,7 +122,134 @@ def get_line_segments(
     return s1, s2
 
 
-# @numba.njit(cache=True)
+@numba.njit(cache=True)
+def shortest_grid_distance(points, s1, s2, axis, signed=True, sign_factor=1):
+    other_axis = int(~bool(axis))
+    x_level = s1[other_axis]  # x-coordinate of the vertical line
+    y_min, y_max = s1[axis], s2[axis]
+
+    # Points that project onto the segment (y between y_min and y_max)
+    mask_on_segment = (points[:, axis] >= y_min) & (points[:, axis] <= y_max)
+
+    # Initialize distance vector
+    dist_vec = np.zeros_like(points)
+
+    # For points that project onto the segment (y within bounds)
+    x_diff = points[:, other_axis] - x_level
+    dist_vec[mask_on_segment, other_axis] = x_diff[mask_on_segment]
+
+    # For points below the segment
+    mask_below = points[:, axis] < y_min
+    dist_vec[mask_below] = points[mask_below] - s1
+
+    # For points above the segment
+    mask_above = points[:, axis] > y_max
+    dist_vec[mask_above] = points[mask_above] - s2
+
+    # Compute sign for segment (positive to the right for vertical and positive below for horizontal)
+    if signed:
+        sign_vec_norm = np.ones(len(points))
+        sign_vec_norm[x_diff > 0 if sign_factor == 1 else x_diff < 0] = -1
+    else:
+        sign_vec_norm = np.ones(len(points))
+
+    return dist_vec, sign_vec_norm
+
+
+@numba.guvectorize(
+    [
+        "void(float32[:], float32[:], float32[:, :], float32, boolean, float32[:], float32[:])",
+        "void(float64[:], float64[:], float64[:, :], float64, boolean, float64[:], float64[:])",
+    ],
+    "(d),(d),(n,d),(),()->(n),(n)",
+    nopython=True,
+    target="parallel",
+)
+def diagonal_segment_distance(s1, s2, points, tol, signed, dist_result, sign_result):
+    """Calculate distances from points to a diagonal line segment.
+
+    Parameters
+    ----------
+    s1 : ndarray
+        First point of the segment (2D)
+    s2 : ndarray
+        Second point of the segment (2D)
+    points : ndarray
+        Array of points to calculate distances from
+    tol : float
+        Tolerance for numerical calculations
+    signed : bool
+        Whether to return signed distances
+    dist_result : ndarray
+        Output array for distances
+    sign_result : ndarray
+        Output array for signs
+    """
+    n_points = points.shape[0]
+
+    # Calculate segment direction vector (unit vector)
+    seg_length = np.sqrt((s2[0] - s1[0]) ** 2 + (s2[1] - s1[1]) ** 2)
+    n_x = (s2[0] - s1[0]) / seg_length
+    n_y = (s2[1] - s1[1]) / seg_length
+
+    for i in range(n_points):
+        # Vector from s1 to point
+        diff_x = s1[0] - points[i, 0]
+        diff_y = s1[1] - points[i, 1]
+
+        # Dot product of diff_s1 and n
+        dot_product = diff_x * n_x + diff_y * n_y
+
+        # Projection distance along the segment
+        proj_dist = -dot_product
+
+        # Initialize distance vector
+        dist_vec_x = 0.0
+        dist_vec_y = 0.0
+
+        if proj_dist < 0:
+            # Closest point is s1
+            dist_vec_x = diff_x
+            dist_vec_y = diff_y
+
+        elif proj_dist > seg_length:
+            # Closest point is s2
+            dist_vec_x = s2[0] - points[i, 0]
+            dist_vec_y = s2[1] - points[i, 1]
+
+        else:
+            # Closest point is on the segment
+            dist_vec_x = diff_x - n_x * dot_product
+            dist_vec_y = diff_y - n_y * dot_product
+
+        # Calculate distance
+        normed_dist = np.sqrt(dist_vec_x**2 + dist_vec_y**2)
+
+        # Calculate sign if needed
+        if signed:
+            # Cross product of n and dist_vec
+            sign_vec = n_x * dist_vec_y - n_y * dist_vec_x
+
+            # Push points on surface inside
+            if abs(sign_vec) < tol:
+                sign_vec = -tol
+
+            # Normalize sign
+            sign_vec_norm = -sign_vec / abs(sign_vec)
+
+        else:
+            sign_vec_norm = 1.0
+
+        # Store results
+        if normed_dist < tol:
+            dist_result[i] = tol
+        else:
+            dist_result[i] = normed_dist
+
+        sign_result[i] = sign_vec_norm
+
+
+@numba.njit(cache=True)
 def shortest_distance(
     s1_list: NDArray,
     s2_list: NDArray,
@@ -194,82 +321,21 @@ def shortest_distance(
         else:
             sign_factor = 1
 
-        if abs(s1[0] - s2[0]) < tol:
-            # Compute distances for a vertical segment
-            x_level = s1[0]  # x-coordinate of the vertical line
-            y_min, y_max = s1[1], s2[1]
-
-            # Points that project onto the segment (y between y_min and y_max)
-            mask_on_segment = (points[:, 1] >= y_min) & (points[:, 1] <= y_max)
-
-            # Initialize distance vector
-            dist_vec = np.zeros_like(points)
-
-            # For points that project onto the segment (y within bounds)
-            x_diff = points[:, 0] - x_level
-            dist_vec[mask_on_segment, 0] = x_diff[mask_on_segment]
-            dist_vec[mask_on_segment, 1] = 0
-
-            # For points below the segment
-            mask_below = points[:, 1] < y_min
-            dist_vec[mask_below] = points[mask_below] - s1
-
-            # For points above the segment
-            mask_above = points[:, 1] > y_max
-            dist_vec[mask_above] = points[mask_above] - s2
-
-            # Compute sign for vertical segment (positive to the right if s2>s1)
-            if signed:
-                sign_vec_norm = np.ones(len(points))
-                # If points are to the left of the line, sign is negative
-                sign_vec_norm[x_diff > 0 if sign_factor == 1 else x_diff < 0] = -1
-            else:
-                sign_vec_norm = np.ones(len(points))
-
-            normed_dist = np.abs(
-                np.where(
-                    dist_vec[:, 1] == 0,
-                    dist_vec[:, 0],
-                    _norm(dist_vec),
-                )
+        if (abs(s1[0] - s2[0]) < tol) or (abs(s1[1] - s2[1]) < tol):
+            axis = 1 if abs(s1[0] - s2[0]) < tol else 0
+            # Compute distances for segment
+            dist_vec, sign_vec_norm = shortest_grid_distance(
+                points,
+                s1,
+                s2,
+                axis=axis,
+                signed=signed,
+                sign_factor=sign_factor if axis == 1 else -sign_factor,
             )
-
-        # check if horizontal segment
-        elif abs(s1[1] - s2[1]) < tol:
-            # Compute distances for a horizontal segment
-            y_level = s1[1]  # y-coordinate of the horizontal line
-            x_min, x_max = s1[0], s2[0]
-
-            # Points that project onto the segment (x between x_min and x_max)
-            mask_on_segment = (points[:, 0] >= x_min) & (points[:, 0] <= x_max)
-
-            # Initialize distance vector
-            dist_vec = np.zeros_like(points)
-
-            # For points that project onto the segment (x within bounds)
-            y_diff = points[:, 1] - y_level
-            dist_vec[mask_on_segment, 0] = 0
-            dist_vec[mask_on_segment, 1] = y_diff[mask_on_segment]
-
-            # For points to the left of the segment
-            mask_left = points[:, 0] < x_min
-            dist_vec[mask_left] = points[mask_left] - s1
-
-            # For points to the right of the segment
-            mask_right = points[:, 0] > x_max
-            dist_vec[mask_right] = points[mask_right] - s2
-            # Compute sign for horizontal segment (positive above if s2>s1)
-            if signed:
-                sign_vec_norm = np.ones(len(points))
-                # If points are below the line, sign is negative
-                sign_vec_norm[y_diff < 0 if sign_factor == 1 else y_diff > 0] = -1
-            else:
-                sign_vec_norm = np.ones(len(points))
-
             normed_dist = np.abs(
                 np.where(
-                    dist_vec[:, 0] == 0,
-                    dist_vec[:, 1],
+                    dist_vec[:, axis] == 0,
+                    dist_vec[:, int(~bool(axis))],
                     _norm(dist_vec),
                 )
             )
@@ -311,4 +377,89 @@ def shortest_distance(
             tol,
             normed_dist * sign_vec_norm,
         )
+    return dists
+
+
+@numba.njit(cache=True)
+def iterate_segments(s1, s2, coords_rz, tol, signed):
+    # first sort by lengths longest first
+    segment_lengths = np.sum((s1 - s2) ** 2, axis=1)
+    sort_indices = np.argsort(segment_lengths)[::-1]
+    s1 = s1[sort_indices]
+    s2 = s2[sort_indices]
+
+    dists = np.full(len(coords_rz), np.inf)
+    diffs = s1 - s2
+    perps = np.abs(diffs[:, 0] * diffs[:, 1]) < tol
+    perp_indices = np.where(perps)[0]
+    non_perp_indices = np.where(~perps)[0]
+
+    # get shortest distance to vertical/horizontal surfaces
+    if len(perp_indices) > 0:
+        for start, end in zip(s1[perp_indices], s2[perp_indices]):
+            if (dists == np.inf).all():
+                candidates = np.arange(0, len(coords_rz))
+            else:
+                diff_x = np.abs(end[0] - start[0])
+                axis = 0 if diff_x < tol else 1
+                diff_start = np.abs(coords_rz - start)[:, axis]
+                abs_dists = np.abs(dists)
+                candidates = np.where(diff_start < abs_dists)[0]
+                # only calculate for these if
+                # and between s1 and s2 or dist
+                # in both dimensions to s1/s2 < current min
+                # candidates = np.where(between | close)[0]
+
+            if len(candidates) > 0:
+                start_array = np.ascontiguousarray(start).reshape(1, -1)
+                end_array = np.ascontiguousarray(end).reshape(1, -1)
+
+                dist_candidates = shortest_distance(
+                    start_array,
+                    end_array,
+                    coords_rz[candidates],
+                    tol=tol,
+                    signed=signed,
+                ).flatten()
+
+                mask = np.abs(dist_candidates) < np.abs(dists[candidates])
+                # print(candidates[mask])
+                dists[candidates[mask]] = dist_candidates[mask]
+
+    # compute shortest distances to remaining surfaces
+    # this condition could probably be tightened
+    if len(non_perp_indices) > 0:
+        for start, end in zip(s1[non_perp_indices], s2[non_perp_indices]):
+            # Calculate distance to endpoints
+            dist_to_start_sq = np.sum((coords_rz - start) ** 2, axis=1)
+            dist_to_end_sq = np.sum((coords_rz - end) ** 2, axis=1)
+
+            # Calculate segment length
+            segment_length_sq = np.sum((end - start) ** 2)
+
+            # Triangle inequality test:
+            # If a point is closer to the segment than its current min distance,
+            # then at least one of these must be true:
+            # 1. It's within (current_dist + segment_length) of the start point
+            # 2. It's within (current_dist + segment_length) of the end point
+
+            threshold_dist_sq = (
+                dists**2 + segment_length_sq + (2 * dists * segment_length_sq)
+            )
+
+            candidates = np.where(
+                (dist_to_start_sq < threshold_dist_sq)
+                | (dist_to_end_sq < threshold_dist_sq)
+            )[0]
+
+            if len(candidates) > 0:
+                dist_candidates = shortest_distance(
+                    np.ascontiguousarray(start).reshape(1, -1),
+                    np.ascontiguousarray(end).reshape(1, -1),
+                    coords_rz[candidates, :],
+                    tol=tol,
+                    signed=signed,
+                ).flatten()
+                mask = np.abs(dist_candidates) < np.abs(dists[candidates])
+                dists[candidates[mask]] = dist_candidates[mask]
     return dists

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,47 @@ def test_distances():
     res = np.array([0.0, 5.0, 7.0, 5.0, 5.0])
     assert np.allclose(utils.shortest_distance(s1, s2, points)[:, 0], res)
 
+    # test 90 degree rotation
+    rot = np.array(
+        [
+            [np.cos(np.deg2rad(90)), -np.sin(np.deg2rad(90))],
+            [np.sin(np.deg2rad(90)), np.cos(np.deg2rad(90))],
+        ]
+    )
+
+    points_new = np.array([rot @ (p_tmp) for p_tmp in points])
+    s1_new = np.array([rot @ (s1_t) for s1_t in s1])
+    s2_new = np.array([rot @ (s2_t) for s2_t in s2])
+    assert np.allclose(
+        utils.shortest_distance(s1_new, s2_new, points_new)[:, 0],
+        res,
+    )
+
+    # test 180 degree rotation of surface but not points
+    s1_new = np.array([[1, 0]])
+    s2_new = np.array([[0, 0]])
+
+    assert np.allclose(
+        utils.shortest_distance(s1_new, s2_new, points)[:, 0],
+        -res,
+    )
+
+    # test "tapered" segment
+    rot = np.array(
+        [
+            [np.cos(np.deg2rad(45)), -np.sin(np.deg2rad(45))],
+            [np.sin(np.deg2rad(45)), np.cos(np.deg2rad(45))],
+        ]
+    )
+
+    points_new = np.array([rot @ (p_tmp) for p_tmp in points])
+    s1_new = np.array([rot @ (s1_t) for s1_t in s1])
+    s2_new = np.array([rot @ (s2_t) for s2_t in s2])
+    assert np.allclose(
+        utils.shortest_distance(s1_new, s2_new, points_new)[:, 0],
+        res,
+    )
+
     # all distances shouldn't be affected by a global offset and rotation
     offset = np.array([107, -203])
     rot = np.array(


### PR DESCRIPTION
Need to test more but this pr adds a simpler method to calculate horizontal/vertical segments, around 2x faster in simple test but need to test more to get accurate picture. This applies to most of our surfaces as most are horizontal/vertical.

Calculate horizontal /vertical first and then only calculate other segments if they are likely to be closer. 

Also clean up is_inside