### PR TITLE
Add methods for the borehole

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pint != 0.24",
     "pyg4ometry",
     "dbetto",
+    "awkward",
     "pyarrow",
 ]
 dynamic = [

--- a/src/legendhpges/invcoax.py
+++ b/src/legendhpges/invcoax.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from pyg4ometry import geant4
+
+from . import utils
 from .base import HPGe
 from .build_utils import make_pplus
 
 
 class InvertedCoax(HPGe):
     """An inverted-coaxial point contact germanium detector."""
+
+    def __init__(self, *args, **kwargs):
+        self.borehole_z = []
+        self.borehole_r = []
+
+        super().__init__(*args, **kwargs)
 
     def _decode_polycone_coord(self) -> tuple[list[float], list[float]]:
         c = self.metadata.geometry
@@ -18,6 +29,10 @@ class InvertedCoax(HPGe):
         r = []
         z = []
         surfaces = []
+
+        # save the borehole coords
+        borehole_r = []
+        borehole_z = []
 
         r_p, z_p, surface_p = make_pplus(c)
         r += r_p
@@ -60,6 +75,10 @@ class InvertedCoax(HPGe):
             z += [c.height_in_mm]
             surfaces += ["nplus"]
 
+        # first point of the borehole
+        borehole_r += [0]
+        borehole_z += [c.height_in_mm]
+
         if c.taper.borehole.height_in_mm > 0:
             r += [
                 c.borehole.radius_in_mm
@@ -73,11 +92,18 @@ class InvertedCoax(HPGe):
             ]
             surfaces += ["nplus", "nplus"]
 
+            # add borehole coords
+            borehole_r += r[-2:]
+            borehole_z += z[-2:]
         else:
             r += [c.borehole.radius_in_mm]
             z += [c.height_in_mm]
             surfaces += ["nplus"]
 
+            borehole_r += [r[-1]]
+            borehole_z += [z[-1]]
+
+        # add borehole with or without tapering
         if c.taper.borehole.height_in_mm != c.borehole.depth_in_mm:
             r += [
                 c.borehole.radius_in_mm,
@@ -90,12 +116,56 @@ class InvertedCoax(HPGe):
             ]
             surfaces += ["nplus", "nplus"]
 
+            borehole_r += r[-2:]
+            borehole_z += z[-2:]
+
         else:
             r += [0]
 
             z += [c.height_in_mm - c.borehole.depth_in_mm]
             surfaces += ["nplus"]
 
+            borehole_r += [r[-1]]
+            borehole_z += [z[-1]]
+
         self.surfaces = surfaces
 
+        # save the borehole coordinates for future reference
+
+        # reverse to keep clockwise orientation
+        self.borehole_r = borehole_r[::-1]
+        self.borehole_z = borehole_z[::-1]
+
         return r, z
+
+    def is_inside_borehole(self, coords: ArrayLike, tol: float = 1e-11) -> NDArray:
+        """Check if a point is inside the ICPC borehole
+
+        Parameters
+        ----------
+        coords
+            2D array of shape `(n,3)` of `(x,y,z)` coordinates for each of `n`
+            points, second index corresponds to `(x,y,z)`.
+        tol
+            distance outside the surface which is considered inside. Should be
+            on the order of numerical precision of the floating point representation.
+        """
+        if not isinstance(self.solid, geant4.solid.GenericPolycone):
+            msg = f"is_inside_borehole is not implemented for {type(self.solid)} yet"
+            raise NotImplementedError(msg)
+
+        if not isinstance(coords, np.ndarray):
+            coords = np.array(coords)
+
+        if np.shape(coords)[1] != 3:
+            msg = "coords must be provided as a 2D array with x,y,z coordinates for each point."
+            raise ValueError(msg)
+
+        r, z = self.borehole_r, self.borehole_z
+
+        coords_rz = utils.convert_coords(coords)
+        s1, s2 = utils.get_line_segments(r, z)
+
+        dists = utils.iterate_segments(s1, s2, coords_rz, tol, signed=True)
+
+        return np.where(dists >= 0, True, False)

--- a/src/legendhpges/invcoax.py
+++ b/src/legendhpges/invcoax.py
@@ -166,14 +166,14 @@ class InvertedCoax(HPGe):
 
         coords_rz = utils.convert_coords(coords)
         s1, s2 = utils.get_line_segments(r, z)
-        print(s1,s2)
+
         # get the distance for each line segment
         dists = utils.shortest_distance(s1, s2, coords_rz, tol, signed=True)
 
         # find the minimal distance
         # if we have two of the same sign take the negative value
-        # this is correct as long as we dont have angles > 180 deg 
-        
+        # this is correct as long as we dont have angles > 180 deg
+
         abs_arr = np.abs(dists)
         min_vals = ak.min(abs_arr, axis=1)
 
@@ -181,6 +181,6 @@ class InvertedCoax(HPGe):
         dists = ak.Array(dists)
 
         min_dist = ak.min(dists[is_min], axis=-1)
-        sign = ak.where(min_dist >= 0, True,False)
+        sign = ak.where(min_dist >= 0, True, False)
 
         return np.array(sign)

--- a/src/legendhpges/invcoax.py
+++ b/src/legendhpges/invcoax.py
@@ -181,6 +181,6 @@ class InvertedCoax(HPGe):
         dists = ak.Array(dists)
 
         min_dist = ak.min(dists[is_min], axis=-1)
-        sign = ak.where(min_dist > 0, 1, -1)
+        sign = ak.where(min_dist >= 0, True,False)
 
         return np.array(sign)

--- a/src/legendhpges/invcoax.py
+++ b/src/legendhpges/invcoax.py
@@ -183,4 +183,4 @@ class InvertedCoax(HPGe):
         min_dist = ak.min(dists[is_min], axis=-1)
         sign = ak.where(min_dist >= 0, True, False)
 
-        return np.array(sign)
+        return sign.to_numpy()

--- a/src/legendhpges/invcoax.py
+++ b/src/legendhpges/invcoax.py
@@ -166,6 +166,7 @@ class InvertedCoax(HPGe):
 
         coords_rz = utils.convert_coords(coords)
         s1, s2 = utils.get_line_segments(r, z)
+
         # get the distance for each line segment
         dists = utils.shortest_distance(s1, s2, coords_rz, tol, signed=True)
 

--- a/src/legendhpges/utils.py
+++ b/src/legendhpges/utils.py
@@ -180,7 +180,10 @@ def shortest_grid_distance(points, s1, s2, axis, signed=True, sign_factor=1):
     # Compute sign for segment (positive to the right for vertical and positive below for horizontal)
     if signed:
         sign_vec_norm = np.ones(len(points))
-        sign_vec_norm[x_diff > 0 if sign_factor == 1 else x_diff < 0] = -1
+
+        mask = x_diff > 0 if sign_factor == 1 else x_diff < 0
+        sign_vec_norm[mask] = -1
+
     else:
         sign_vec_norm = np.ones(len(points))
 

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -110,7 +110,7 @@ def test_shortest_grid_dist():
     s1 = np.array([0, 0])
     s2 = np.array([0, 1])
     axis = 1 if abs(s1[0] - s2[0]) < 1e-11 else 0
-    sign_factor = (1 if axis == 1 else -1,)
+    sign_factor = 1 if axis == 1 else -1
 
     dist_vec, sign = shortest_grid_distance(
         np.array([[0.5, 0.5], [0.5, 2], [0.5, -1]]),
@@ -160,7 +160,7 @@ def test_shortest_grid_dist():
     s1 = np.array([0, 0])
     s2 = np.array([1, 0])
     axis = 1 if abs(s1[0] - s2[0]) < 1e-11 else 0
-    sign_factor = (1 if axis == 1 else -1,)
+    sign_factor = 1 if axis == 1 else -1
 
     dist_vec, sign = shortest_grid_distance(
         np.array([[0.5, 0.5], [2, 0.5], [-1, 0.5]]),
@@ -175,3 +175,23 @@ def test_shortest_grid_dist():
     assert np.all(dist_vec[1] == np.array([1, 0.5]))
     assert np.all(dist_vec[2] == np.array([-1, 0.5]))
     assert np.all(sign == [1, 1, 1])
+
+
+def test_is_in_borehole(test_data_configs):
+    gedet = make_hpge(test_data_configs + "/V99000A.json", registry=None)
+
+    # simple borehole (cylinder)
+    assert len(gedet.borehole_r) == 4
+    assert len(gedet.borehole_z) == 4
+
+    is_in = gedet.is_inside_borehole(
+        np.array(
+            [
+                [3, 10, 10],  # in Ge not borehole
+                [4, 0, 30],  # in borehole
+                [20, 30, 50],
+            ]
+        )
+    )  # outside
+
+    assert np.all(is_in == [False, True, False])

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -9,6 +9,7 @@ from legendtestdata import LegendTestData
 from pyg4ometry import geant4
 
 from legendhpges import make_hpge
+from legendhpges.utils import shortest_grid_distance
 
 configs = TextDB(pathlib.Path(__file__).parent.resolve() / "configs")
 
@@ -102,3 +103,75 @@ def test_inside_output(test_data_configs, reg):
     is_in = gedet.is_inside(coords, tol=1e-11)
 
     assert np.all(is_in == np.array([True, False, False, True, False, True, False]))
+
+
+def test_shortest_grid_dist():
+    # vertical line
+    s1 = np.array([0, 0])
+    s2 = np.array([0, 1])
+    axis = 1 if abs(s1[0] - s2[0]) < 1e-11 else 0
+    sign_factor = (1 if axis == 1 else -1,)
+
+    dist_vec, sign = shortest_grid_distance(
+        np.array([[0.5, 0.5], [0.5, 2], [0.5, -1]]),
+        s1,
+        s2,
+        axis,
+        signed=True,
+        sign_factor=sign_factor,
+    )
+
+    # first point is adjacent
+    assert np.all(dist_vec[0] == np.array([0.5, 0]))
+
+    # second is above
+    assert np.all(dist_vec[1] == np.array([0.5, 1]))
+
+    # third is below
+    assert np.all(dist_vec[2] == np.array([0.5, -1]))
+
+    # all are outside
+    assert np.all(sign == [-1, -1, -1])
+
+    # try inside points
+    dist_vec, sign = shortest_grid_distance(
+        np.array([[-0.5, 0.5], [-0.5, 2], [-0.5, -1]]),
+        s1,
+        s2,
+        axis,
+        signed=True,
+        sign_factor=sign_factor,
+    )
+
+    # first point is adjacent
+    assert np.all(dist_vec[0] == np.array([-0.5, 0]))
+
+    # second is above
+    assert np.all(dist_vec[1] == np.array([-0.5, 1]))
+
+    # third is below
+    assert np.all(dist_vec[2] == np.array([-0.5, -1]))
+
+    # all are outside
+    assert np.all(sign == [1, 1, 1])
+
+    # horizontal line
+
+    s1 = np.array([0, 0])
+    s2 = np.array([1, 0])
+    axis = 1 if abs(s1[0] - s2[0]) < 1e-11 else 0
+    sign_factor = (1 if axis == 1 else -1,)
+
+    dist_vec, sign = shortest_grid_distance(
+        np.array([[0.5, 0.5], [2, 0.5], [-1, 0.5]]),
+        s1,
+        s2,
+        axis,
+        signed=True,
+        sign_factor=sign_factor,
+    )
+
+    assert np.all(dist_vec[0] == np.array([0, 0.5]))
+    assert np.all(dist_vec[1] == np.array([1, 0.5]))
+    assert np.all(dist_vec[2] == np.array([-1, 0.5]))
+    assert np.all(sign == [1, 1, 1])


### PR DESCRIPTION
This adds a function to check if a point is inside the HPGe borehole, this is useful for primary generation and for post processing.
It did reveal however that some of the geometry methods for signed distances are a bit unstable... this should handle the case of convex corners in the geometry (< 90 deg), but not the case of concave (< 90 deg).

We should maybe add these checks in future and try to make all this geometry code more robust (@ggmarshall ?)